### PR TITLE
Force backslashes to slashes for embedded paths

### DIFF
--- a/tools/create_assets.py
+++ b/tools/create_assets.py
@@ -56,7 +56,7 @@ def list_files(group):
 	for root, dirs, files in os.walk("data/%s" % group):
 		for f in files:
 			if any(f.endswith('.' + x) for x in TYPES):
-				ret.append(os.path.join(root, f))
+				ret.append(os.path.join(root, f).replace("\\", "/"))
 
 	return sorted(ret, key=lambda x: x.upper())
 


### PR DESCRIPTION
On Windows the paths are joined using backslashes, but these backslashes are not properly escaped for a C string when printed, resulting in the wrong string in the include. I ran into this when building csprite natively on Windows using Mingw-w64 ([via](https://github.com/skeeto/w64devkit)).

More generally, to successfully build and run (in place) on Windows — which I was happy to see working! — I also had to:

1. Adjust `subprocess.run(['clang++', ...]` to `'g++'`
2. Add SDL2 `-I`/`-L` paths to `CCFLAGS`/`LFLAGS` (alternative: install SDL2 in the GCC sysroot like on other platforms)
3. Adjust `python3` to `python` since that's what it's named on Windows

For (1), this could be `'c++'` to invoke the system's primary C++ compiler, whether that's `clang++` or `g++`, just like `cc` for the C compiler. (Note: You can do the same with `CXX` in the Makefile.)

For (2) the Makefile could use `sdl2-config`, which is part of SDL2 and exists specifically to solve this problem. (Note the double `$$`.)

    CCFLAGS:=... $$(sdl2-config --cflags)
    LFLAGS+=... $$(sdl2-config --static-libs) ...   # static link
    LFLAGS+=... $$(sdl2-config --libs) ...          # dynamic link

The sources also need to be updated to include `SDL.h` rather than `SDL2/SDL.h` which is the incorrect include anyway. (Maybe also get rid of `-DSDL_MAIN_HANDLED=1` since it doesn't seem to serve a purpose in this case? I suspect it's only there to simplify linking.)

For (3) add a `PYTHON` variable *a la* `CXX`. This would also work better in virtual environments, e.g. `make PYTHON=venv/bin/python`.