### PR TITLE
Fix crash when layer is renamed to an empty string & disable empty layer names

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -575,18 +575,24 @@ IncrementAndCreateLayer__:
 		if (ShowLayerRenameWindow) {
 			if (ImGui::BeginPopupModal("Rename Layer###LayerRenameWindow", NULL, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_AlwaysAutoResize)) {
 				static char TempBuff[LAYER_NAME_MAX] = "";
+				static bool LayerRenamed;
+
+				LayerRenamed = false;
 
 				if (ImGui::InputText("##NewLayerName", TempBuff, LAYER_NAME_MAX, ImGuiInputTextFlags_EnterReturnsTrue)) {
-					strncpy(CURR_CANVAS_LAYER->name, TempBuff, LAYER_NAME_MAX);
-					memset(TempBuff, 0, LAYER_NAME_MAX);
-					ShowLayerRenameWindow = false;
+					LayerRenamed = true;
 				}
 
 				if (ImGui::Button("Ok")) {
+					LayerRenamed = true;
+				}
+
+				if (LayerRenamed && TempBuff[0] != '\0') {
 					strncpy(CURR_CANVAS_LAYER->name, TempBuff, LAYER_NAME_MAX);
 					memset(TempBuff, 0, LAYER_NAME_MAX);
 					ShowLayerRenameWindow = false;
 				}
+
 				ImGui::SameLine();
 				if (ImGui::Button("Cancel")) {
 					ShowLayerRenameWindow = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -595,6 +595,7 @@ IncrementAndCreateLayer__:
 
 				ImGui::SameLine();
 				if (ImGui::Button("Cancel")) {
+					memset(TempBuff, 0, LAYER_NAME_MAX);
 					ShowLayerRenameWindow = false;
 				}
 				ImGui::EndPopup();


### PR DESCRIPTION
Hi! Two little patches here

* fix crash when a layer is renamed to an empty string
    * dont allow empty layer names
 
* clear TempBuff when hitting the Cancel button, otherwise the input text box would contain previous entered text

Happy new year!