### PR TITLE
Add a layer alpha slider for easier image editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the beautiful icon & banner are created ["Birds Probably" aka Lilith](https://ww
 ---
 ### Todo
 - [x] Custom File Format (.csprite)
-- [ ] Configurable Alpha For Each Layer
+- [x] Configurable Alpha For Each Layer
 - [ ] Configurable Blend Mode For Each Layer
 - [x] ReFactor Code
 - [x] Add Layers Support

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -803,10 +803,9 @@ int main(int argc, char* argv[]) {
 				if (ImGui::Selectable(CanvasLayerMgr->layers[i]->name.c_str(), CanvasLayerMgr->CurrentLayerIdx == i, ImGuiSelectableFlags_AllowDoubleClick)) {
 					if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
 						ShowLayerRenameWindow = true;
-						CanvasLayerMgr->SetCurrentLayerIdx(i);
-					} else {
-						CanvasLayerMgr->SetCurrentLayerIdx(i);
 					}
+
+					CanvasLayerMgr->SetCurrentLayerIdx(i);
 				}
 
 				if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceNoDisableHover | ImGuiDragDropFlags_SourceNoHoldToOpenOthers)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,7 +407,7 @@ int main(int argc, char* argv[]) {
 						REDO();
 				}
 				if (ImGui::MenuItem("Draw/Erase/Fill/InkDropper", "Left Mouse", false, 0)) {
-					
+
 				}
 				ImGui::EndMenu();
 			}
@@ -796,11 +796,14 @@ int main(int argc, char* argv[]) {
 				}
 			}
 
+			ImGui::SliderFloat("Alpha", &CanvasLayerMgr->layers[CanvasLayerMgr->CurrentLayerIdx]->alpha, 0.0f, 1.0f);
+
 			int move_from = -1, move_to = -1;
 			for (int32_t i = 0; i < CanvasLayerMgr->layers.size(); ++i) {
 				if (ImGui::Selectable(CanvasLayerMgr->layers[i]->name.c_str(), CanvasLayerMgr->CurrentLayerIdx == i, ImGuiSelectableFlags_AllowDoubleClick)) {
 					if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
 						ShowLayerRenameWindow = true;
+						CanvasLayerMgr->SetCurrentLayerIdx(i);
 					} else {
 						CanvasLayerMgr->SetCurrentLayerIdx(i);
 					}

--- a/src/renderer/canvas.cpp
+++ b/src/renderer/canvas.cpp
@@ -7,6 +7,7 @@ CanvasLayer::CanvasLayer(SDL_Renderer* ren, int32_t w, int32_t h, std::string na
 	this->pixels = new Pixel[w * h];
 	this->tex = SDL_CreateTexture(ren, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STREAMING, w, h);
 	this->history = NULL;
+	this->alpha = 1.f;
 	SaveHistory(&this->history, w * h, this->pixels);
 
 	if (SDL_SetTextureBlendMode(this->tex, SDL_BLENDMODE_BLEND) != 0) {
@@ -94,10 +95,12 @@ void CanvasLayer_Manager::Draw(SDL_Rect* r, int32_t layerToUpdateIdx) {
 	SDL_SetRenderTarget(this->ren, this->render);
 	SDL_RenderCopy(this->ren, this->pattern, NULL, NULL);
 
+
 	for (int32_t i = 0; i < this->layers.size(); ++i) {
 		if (layerToUpdateIdx == i) {
 			SDL_UpdateTexture(this->layers[i]->tex, NULL, this->layers[i]->pixels, this->dims[0] * sizeof(Pixel));
 		}
+	  SDL_SetTextureAlphaMod(this->layers[i]->tex, this->layers[i]->alpha * 255);
 		SDL_RenderCopy(this->ren, this->layers[i]->tex, NULL, NULL);
 	}
 

--- a/src/renderer/canvas.h
+++ b/src/renderer/canvas.h
@@ -13,6 +13,7 @@ struct CanvasLayer {
 	SDL_Texture* tex;
 	Pixel*       pixels;
 	History_T*   history;
+	float        alpha;
 
 	CanvasLayer(SDL_Renderer* ren, int32_t w, int32_t h, std::string name = "New Layer");
 	~CanvasLayer();


### PR DESCRIPTION
A feature I need in a pixel art editor is to temporarily make some layers semi-transparent so that I can work on something. This PR adds an alpha-slider that allows the user to temporarily change the alpha of a layer. This is not reflected in the final image nor is this saved beyond the session in which the alpha is set. Will add to save-data if felt necessary (in my opinion isn't)